### PR TITLE
Make ansible-lint happy

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -7,4 +7,5 @@
   service: name=ocserv state=reloaded
 
 - name: reload systemd
-  command: systemctl daemon-reload
+  systemd:
+    daemon_reload: yes

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   description: OpenConnect SSL VPN Server (ocserv)
   license: Apache
 
-  min_ansible_version: 2.0
+  min_ansible_version: 2.4
 
   platforms:
     - name: Ubuntu
@@ -18,5 +18,5 @@ galaxy_info:
     - openconnect
     - sslvpn
     - vpn
-  
+
 dependencies: []


### PR DESCRIPTION
Ansible-lint through a couple warnings when run against
this role.  I udpated the two warnings, and also raised
the minimum ansible version required for the systemd change.